### PR TITLE
Fix JOIN queries

### DIFF
--- a/examples/src/main/java/com/keenant/flow/examples/MySQLExample.java
+++ b/examples/src/main/java/com/keenant/flow/examples/MySQLExample.java
@@ -17,7 +17,7 @@ public class MySQLExample {
         "jdbc:mysql://localhost/flow?user=root&password=password")) {
       Query query = db.prepareFetch("SELECT * FROM people");
       try (Stream<Cursor> stream = query.execute().eagerCursor().stream()) {
-        stream.forEach(c -> System.out.println(c.toLabelMap()));
+        stream.forEach(c -> System.out.println(c.toIndexMap()));
       }
     }
   }

--- a/examples/src/main/java/com/keenant/flow/examples/SQLiteExample.java
+++ b/examples/src/main/java/com/keenant/flow/examples/SQLiteExample.java
@@ -16,6 +16,7 @@ import com.keenant.flow.EagerCursor;
 import com.keenant.flow.SQLDialect;
 import com.keenant.flow.SelectScoped;
 import com.keenant.flow.exp.FieldExp;
+import com.keenant.flow.exp.PlainExp;
 import java.util.stream.Stream;
 
 public class SQLiteExample {
@@ -71,7 +72,9 @@ public class SQLiteExample {
       }
 
       // Flow stream
-      SelectScoped query = db.selectFrom(USERS).fields(NAME, AGE).where(ID.lt(50))
+      SelectScoped query = db.selectFrom(USERS)
+          .fields(NAME, AGE)
+          .where(ID.lt(50))
           .order(orderAsc(AGE));
       try (Stream<Cursor> stream = query.fetch().stream()) {
         stream.forEach(current -> {

--- a/flow/src/main/java/com/keenant/flow/AbstractBinaryExp.java
+++ b/flow/src/main/java/com/keenant/flow/AbstractBinaryExp.java
@@ -7,7 +7,6 @@ import java.util.List;
  * An expression that takes two parameters.
  */
 public abstract class AbstractBinaryExp extends AbstractExp {
-
   private final Exp child1;
   private final Exp child2;
 

--- a/flow/src/main/java/com/keenant/flow/AbstractBinaryFilter.java
+++ b/flow/src/main/java/com/keenant/flow/AbstractBinaryFilter.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractBinaryFilter extends AbstractFilter {
-
   private final Filter filter1;
   private final Filter filter2;
 

--- a/flow/src/main/java/com/keenant/flow/AbstractRecord.java
+++ b/flow/src/main/java/com/keenant/flow/AbstractRecord.java
@@ -10,24 +10,12 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 public abstract class AbstractRecord implements Record {
-
   @Override
   public Map<Integer, Object> toIndexMap() {
     Map<Integer, Object> result = new LinkedHashMap<>(); // preserve insertion order
     int current = 1;
     while (hasField(current)) {
       result.put(current, get(current).orElse(null));
-      current++;
-    }
-    return result;
-  }
-
-  @Override
-  public Map<String, Object> toLabelMap() {
-    Map<String, Object> result = new LinkedHashMap<>(); // preserve insertion order
-    int current = 1;
-    while (hasField(current)) {
-      result.put(getFieldLabel(current), get(current).orElse(null));
       current++;
     }
     return result;

--- a/flow/src/main/java/com/keenant/flow/EagerCursor.java
+++ b/flow/src/main/java/com/keenant/flow/EagerCursor.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class EagerCursor extends Cursor {
-
   private ResultSet resultSet;
 
   public EagerCursor(PreparedStatement statement, ResultSet resultSet) {

--- a/flow/src/main/java/com/keenant/flow/Exp.java
+++ b/flow/src/main/java/com/keenant/flow/Exp.java
@@ -4,6 +4,7 @@ import com.keenant.flow.exp.AsExp;
 import com.keenant.flow.exp.FieldExp;
 import com.keenant.flow.exp.OnExp;
 import com.keenant.flow.exp.ParamExp;
+import com.keenant.flow.exp.PlainExp;
 import com.keenant.flow.exp.functions.AbsExp;
 import com.keenant.flow.exp.functions.AvgExp;
 import com.keenant.flow.exp.functions.CountExp;
@@ -246,11 +247,24 @@ public interface Exp extends QueryPartBuilder {
     return new AsExp(this, as);
   }
 
-  default AsExp as(Object as) {
-    return as(new ParamExp(as));
-  }
-
   default FieldExp qualify(Exp qualifier) {
     return new FieldExp(this, qualifier);
+  }
+
+  default FieldExp specify(Exp child) {
+    return specify(child, true);
+  }
+
+  default FieldExp specify(Exp child, boolean overrideQualifier) {
+    Exp result = child;
+
+    if (child instanceof FieldExp) {
+      FieldExp childField = (FieldExp) child;
+      if (overrideQualifier) {
+        result = childField.getField();
+      }
+    }
+
+    return new FieldExp(result, this);
   }
 }

--- a/flow/src/main/java/com/keenant/flow/Record.java
+++ b/flow/src/main/java/com/keenant/flow/Record.java
@@ -12,7 +12,6 @@ import java.util.Optional;
  * Represents something that may currently point to a record/row in the database.
  */
 public interface Record {
-
   /**
    * Check if a field exists.
    *
@@ -35,7 +34,7 @@ public interface Record {
    *
    * @param label the field label
    * @return the field
-   * @throws IllegalArgumentException if the field label provided is null
+   * @throws IllegalArgumentException if the field label provided is null, or has multiple indexes
    * @throws NoSuchElementException if the field label is not present
    */
   int getFieldIndex(String label) throws IllegalArgumentException, NoSuchElementException;
@@ -50,8 +49,6 @@ public interface Record {
   String getFieldLabel(int index) throws NoSuchElementException;
 
   Map<Integer, Object> toIndexMap();
-
-  Map<String, Object> toLabelMap();
 
   <T, U> Optional<U> get(int field, Transformer<T, U> transformer)
       throws NoSuchElementException, ClassCastException;

--- a/flow/src/main/java/com/keenant/flow/Select.java
+++ b/flow/src/main/java/com/keenant/flow/Select.java
@@ -79,6 +79,16 @@ public class Select {
     sql.append(tablePart.getSql());
     params.addAll(tablePart.getParams());
 
+    if (joins != null) {
+      sql.append(" JOIN ");
+      this.joins.stream().map(j -> j.build(dialect)).forEach(joinPart -> {
+        sql.append(joinPart.getSql());
+        params.addAll(joinPart.getParams());
+        sql.append(" ");
+      });
+      sql.deleteCharAt(sql.length() - 1);
+    }
+
     if (filterPart != null) {
       sql.append(" WHERE ");
 
@@ -91,15 +101,6 @@ public class Select {
 
       sql.append(orderPart.getSql());
       params.addAll(orderPart.getParams());
-    }
-
-    if (joins != null) {
-      this.joins.stream().map(j -> j.build(dialect)).forEach(joinPart -> {
-        sql.append(joinPart.getSql());
-        params.addAll(joinPart.getParams());
-        sql.append(" ");
-      });
-
     }
 
     return new QueryPart(sql.toString(), params);

--- a/flow/src/main/java/com/keenant/flow/SelectScoped.java
+++ b/flow/src/main/java/com/keenant/flow/SelectScoped.java
@@ -4,7 +4,6 @@ import com.keenant.flow.exception.DatabaseException;
 import java.util.Collection;
 
 public class SelectScoped implements QueryPartBuilder {
-
   private final Select select;
   private final DatabaseContext database;
   private final SQLDialect dialect;

--- a/flow/src/main/java/com/keenant/flow/exp/FieldExp.java
+++ b/flow/src/main/java/com/keenant/flow/exp/FieldExp.java
@@ -6,9 +6,9 @@ import com.keenant.flow.QueryPart;
 import com.keenant.flow.SQLDialect;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class FieldExp extends AbstractExp {
-
   private final Exp field;
   private final Exp qualifier;
 
@@ -23,6 +23,14 @@ public class FieldExp extends AbstractExp {
   public FieldExp(Exp field, Exp qualifier) {
     this.field = field;
     this.qualifier = qualifier;
+  }
+
+  public Exp getField() {
+    return field;
+  }
+
+  public Optional<Exp> getQualifier() {
+    return Optional.ofNullable(qualifier);
   }
 
   /**


### PR DESCRIPTION
Removed toLabelMap() because duplicate labels can exist
upon joining tables which have columns of the same name.